### PR TITLE
Fluid Automation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ dependencies {
     compile fg.deobf("curse.maven:titanium-287342:3346366")
     compile fg.deobf("curse.maven:pipez-443900:3273405")
 
-//    implementation fg.deobf("curse.maven:cyclic-239286:3249448")
+    implementation fg.deobf("curse.maven:cyclic-239286:3384234")
 //    implementation fg.deobf("curse.maven:simple-storage-network-268495:3230736")
 //    implementation fg.deobf("curse.maven:simple-tomb-399669:3229015")
     

--- a/src/main/java/mrbysco/forcecraft/capablilities/FluidHandlerWrapper.java
+++ b/src/main/java/mrbysco/forcecraft/capablilities/FluidHandlerWrapper.java
@@ -20,8 +20,8 @@ public class FluidHandlerWrapper implements IFluidHandler, INBTSerializable<Comp
 	protected final FluidTank tankOutput; // output is fuel
 
 	public FluidHandlerWrapper(FluidTank input, FluidTank output) {
-		this.tankOutput = input;
-		this.tankInput = output;
+		this.tankInput = input;
+		this.tankOutput  = output;
 	}
 
 	@Override

--- a/src/main/java/mrbysco/forcecraft/capablilities/FluidHandlerWrapper.java
+++ b/src/main/java/mrbysco/forcecraft/capablilities/FluidHandlerWrapper.java
@@ -1,0 +1,80 @@
+package mrbysco.forcecraft.capablilities;
+
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.templates.FluidTank;
+import net.minecraftforge.items.ItemStackHandler;
+
+/**
+ * Wraps two {@link ItemStackHandler}s: Input and Output. Input's slots come first then the Output's slots come after. Items can only be inserted into Input. Items can only be extracted from Output.
+ * Note that the above only applies to operations on the wrapper, the backing handlers are not restricted. For persistence, either the backing {@link ItemStackHandler}s can be saved, or the wrapper
+ * itself.
+ */
+public class FluidHandlerWrapper implements IFluidHandler, INBTSerializable<CompoundNBT> {
+
+	public static final String NBT_INPUT = "Input";
+	public static final String NBT_OUTPUT = "Output";
+	protected final FluidTank tankInput; // input is for example coolant
+	protected final FluidTank tankOutput; // output is fuel
+
+	public FluidHandlerWrapper(FluidTank input, FluidTank output) {
+		this.tankOutput = input;
+		this.tankInput = output;
+	}
+
+	@Override
+	public CompoundNBT serializeNBT() {
+		CompoundNBT nbt = new CompoundNBT();
+		nbt.put(NBT_INPUT, tankInput.writeToNBT(new CompoundNBT()));
+		nbt.put(NBT_OUTPUT, tankOutput.writeToNBT(new CompoundNBT()));
+		return nbt;
+	}
+
+	@Override
+	public void deserializeNBT(CompoundNBT nbt) {
+		if (nbt.contains(NBT_OUTPUT))
+			tankOutput.readFromNBT(nbt.getCompound(NBT_OUTPUT));
+		if (nbt.contains(NBT_INPUT))
+			tankInput.readFromNBT(nbt.getCompound(NBT_INPUT));
+
+	}
+
+	@Override
+	public int getTanks() {
+		return 2;
+	}
+
+	@Override
+	public FluidStack getFluidInTank(int tank) {
+		// TODO: we could make an array of tanks, or switch statement to clean up these
+		// maybe
+		return (tank == 0) ? this.tankOutput.getFluid() : tankInput.getFluid();
+	}
+
+	@Override
+	public int getTankCapacity(int tank) {
+		return (tank == 0) ? this.tankOutput.getCapacity() : tankInput.getCapacity();
+	}
+
+	@Override
+	public boolean isFluidValid(int tank, FluidStack stack) {
+		return (tank == 0) ? this.tankOutput.isFluidValid(stack) : tankInput.isFluidValid(stack);
+	}
+
+	@Override
+	public int fill(FluidStack resource, FluidAction action) {
+		return this.tankInput.fill(resource, action);
+	}
+
+	@Override
+	public FluidStack drain(FluidStack resource, FluidAction action) {
+		return this.tankOutput.drain(resource, action);
+	}
+
+	@Override
+	public FluidStack drain(int maxDrain, FluidAction action) {
+		return this.tankOutput.drain(maxDrain, action);
+	}
+}

--- a/src/main/java/mrbysco/forcecraft/capablilities/ItemStackHandlerWrapper.java
+++ b/src/main/java/mrbysco/forcecraft/capablilities/ItemStackHandlerWrapper.java
@@ -1,0 +1,110 @@
+package mrbysco.forcecraft.capablilities;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraftforge.items.ItemStackHandler;
+
+/**
+ * Wraps two {@link ItemStackHandler}s: Input and Output. Input's slots come first then the Output's slots come after. Items can only be inserted into Input. Items can only be extracted from Output.
+ * Note that the above only applies to operations on the wrapper, the backing handlers are not restricted. For persistence, either the backing {@link ItemStackHandler}s can be saved, or the wrapper
+ * itself.
+ */
+public class ItemStackHandlerWrapper implements IItemHandler, IItemHandlerModifiable, INBTSerializable<CompoundNBT> {
+
+  public static final String NBT_INPUT = "Input";
+  public static final String NBT_OUTPUT = "Output";
+  protected final ItemStackHandler input;
+  protected final ItemStackHandler output;
+
+  public ItemStackHandlerWrapper(ItemStackHandler input, ItemStackHandler output) {
+    this.input = input;
+    this.output = output;
+  }
+
+  /**
+   * Calls with the correct handler, slot for the handler and if it matches the input handler.
+   */
+  protected <T> T withHandler(int externalSlot, HandlerCallback<T> callback) {
+    int numInputSlots = input.getSlots();
+    boolean isInput = externalSlot < numInputSlots;
+    int internalSlot = isInput ? externalSlot : externalSlot - numInputSlots;
+    ItemStackHandler handler = isInput ? input : output;
+    return callback.apply(handler, internalSlot, isInput);
+  }
+
+  /**
+   * For functions that return void.
+   *
+   * @see ItemStackHandlerWrapper#withHandler(int, HandlerCallback)
+   */
+  protected void withHandlerV(int slot, HandlerCallbackVoid func) {
+    withHandler(slot, (h, s, isInput) -> {
+      func.apply(h, s, isInput);
+      return false; // Because generics can't be void >.<
+    });
+  }
+
+  @Override
+  public int getSlots() {
+    return input.getSlots() + output.getSlots();
+  }
+
+  @Override
+  public ItemStack getStackInSlot(int slot) {
+    return withHandler(slot, (h, s, isInput) -> h.getStackInSlot(s));
+  }
+
+  @Override
+  public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
+    return withHandler(slot, (h, s, isInput) -> isInput ? h.insertItem(s, stack, simulate) : stack);
+  }
+
+  @Override
+  public ItemStack extractItem(int slot, int amount, boolean simulate) {
+    return withHandler(slot, (h, s, isInput) -> isInput ? ItemStack.EMPTY : h.extractItem(s, amount, simulate));
+  }
+
+  @Override
+  public int getSlotLimit(int slot) {
+    return withHandler(slot, (h, s, isInput) -> h.getSlotLimit(s));
+  }
+
+  @Override
+  public boolean isItemValid(int slot, ItemStack stack) {
+    return withHandler(slot, (h, s, isInput) -> isInput && h.isItemValid(s, stack));
+  }
+
+  @Override
+  public void setStackInSlot(int slot, ItemStack stack) {
+    withHandlerV(slot, (h, s, isInput) -> h.setStackInSlot(s, stack));
+  }
+
+  @Override
+  public CompoundNBT serializeNBT() {
+    CompoundNBT cmp = new CompoundNBT();
+    cmp.put(NBT_INPUT, input.serializeNBT());
+    cmp.put(NBT_OUTPUT, output.serializeNBT());
+    return cmp;
+  }
+
+  @Override
+  public void deserializeNBT(CompoundNBT nbt) {
+    input.deserializeNBT(nbt.getCompound(NBT_INPUT));
+    output.deserializeNBT(nbt.getCompound(NBT_OUTPUT));
+  }
+
+  @FunctionalInterface
+  protected interface HandlerCallback<T> {
+
+    T apply(ItemStackHandler handler, int slot, boolean isInput);
+  }
+
+  @FunctionalInterface
+  protected interface HandlerCallbackVoid {
+
+    void apply(ItemStackHandler handler, int slot, boolean isInput);
+  }
+}


### PR DESCRIPTION
Add IO wrappers for both fluid and items.

Fluid wrapper used in engine tile: force is output fluid, throttle is input.  (nbt tag saving changed so will wipe old blocks/ have to break and replace blocks probably)

ItemStackHandlerWrapper is in PR but not used yet