### PR TITLE
add force tools to appropriate tags

### DIFF
--- a/src/generated/resources/.cache/0ce9513b0186cea52ebc929e2f8c8ccda756a973
+++ b/src/generated/resources/.cache/0ce9513b0186cea52ebc929e2f8c8ccda756a973
@@ -1,2 +1,2 @@
-// 1.21.1	2024-10-02T17:02:16.0475798	Languages: en_us for mod: forcecraft
-71e86cc688b6922398e5f92a69a741a5850cc17e assets/forcecraft/lang/en_us.json
+// 1.21.1	2024-10-31T14:32:25.2100393	Languages: en_us for mod: forcecraft
+869f5e553ca3c0900695a7346e67450fbeb0c5d1 assets/forcecraft/lang/en_us.json

--- a/src/generated/resources/.cache/4c771f18963704254e4ac70d3c4a47862c033e90
+++ b/src/generated/resources/.cache/4c771f18963704254e4ac70d3c4a47862c033e90
@@ -1,8 +1,10 @@
-// 1.21.1	2024-08-31T20:26:51.604925	Tags for minecraft:item mod id forcecraft
+// 1.21.1	2024-10-31T14:33:25.8092152	Tags for minecraft:item mod id forcecraft
 d964b17dbbb1870466808060f50c0991f7cfaf65 data/c/tags/item/ores.json
 f002772c304bb8350635523d7d3bb1c4fdb5796a data/c/tags/item/ores/power.json
 b73848b6920747aedc21ffb8aed7e3aa8d325f04 data/c/tags/item/ores_in_ground/deepslate.json
 5b2618b88b5b044099742e91e0a5e3ed254d91cf data/c/tags/item/ores_in_ground/stone.json
+e05efd811922fbbe385b35f046fa78667f037490 data/c/tags/item/tools/bow.json
+55b2df2a4c01e88a6f28e303e1f2bc4dee7cdfec data/c/tags/item/tools/shear.json
 53afa95f4f2972f61ad4870a14ffdad392433608 data/forcecraft/tags/item/baconator_food.json
 f37c1227f073af48a0e3f526510a90a1f11811d7 data/forcecraft/tags/item/chu_jelly.json
 ca0dfb4cd17d1a8bebda73a2ba9587fde8c1486d data/forcecraft/tags/item/ender.json
@@ -10,4 +12,8 @@ ca0dfb4cd17d1a8bebda73a2ba9587fde8c1486d data/forcecraft/tags/item/ender.json
 ba8baa1de0654d18f27068517c95b5fb869c254a data/forcecraft/tags/item/force_furnace.json
 eff2e9b711edce9a5ae1875f820c2b5272b0779f data/forcecraft/tags/item/force_logs.json
 f6578c63f571b1fa389775ac66b9218c094d5150 data/forcecraft/tags/item/fortune.json
+d0839816bc5ce3b45313754d9906dbff2041e63c data/minecraft/tags/item/axes.json
 d1415442d2f9003a49daa7a187adfa9f33413cf4 data/minecraft/tags/item/meat.json
+ec66e38ccaacb630b256b4fde7d82d7b895d7172 data/minecraft/tags/item/pickaxes.json
+fafc476436a7cda16b83454f46b5a07b7e398a14 data/minecraft/tags/item/shovels.json
+919e6d75ea4faf772493aad779bb387136859c88 data/minecraft/tags/item/swords.json

--- a/src/generated/resources/data/c/tags/item/tools/bow.json
+++ b/src/generated/resources/data/c/tags/item/tools/bow.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "forcecraft:force_bow"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/tools/shear.json
+++ b/src/generated/resources/data/c/tags/item/tools/shear.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "forcecraft:force_shears"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/item/axes.json
+++ b/src/generated/resources/data/minecraft/tags/item/axes.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "forcecraft:force_axe"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/item/pickaxes.json
+++ b/src/generated/resources/data/minecraft/tags/item/pickaxes.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "forcecraft:force_pickaxe"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/item/shovels.json
+++ b/src/generated/resources/data/minecraft/tags/item/shovels.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "forcecraft:force_shovel"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/item/swords.json
+++ b/src/generated/resources/data/minecraft/tags/item/swords.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "forcecraft:force_sword"
+  ]
+}

--- a/src/main/java/com/mrbysco/forcecraft/datagen/data/tags/ForceItemTagProvider.java
+++ b/src/main/java/com/mrbysco/forcecraft/datagen/data/tags/ForceItemTagProvider.java
@@ -13,6 +13,7 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 
 import java.util.concurrent.CompletableFuture;
@@ -83,5 +84,29 @@ public class ForceItemTagProvider extends ItemTagsProvider {
 						ForceRegistry.RED_FORCE_FURNACE.asItem(), ForceRegistry.WHITE_FORCE_FURNACE.asItem());
 
 		this.tag(MEAT).add(ForceRegistry.RAW_BACON.get(), ForceRegistry.COOKED_BACON.get());
+
+//		this.tag(Tags.Items.TOOLS)
+//				.add(ForceRegistry.FORCE_AXE.get(), ForceRegistry.FORCE_PICKAXE.get(),
+//						ForceRegistry.FORCE_SHOVEL.get(), ForceRegistry.FORCE_SWORD.get(),
+//						ForceRegistry.FORCE_BOW.get(), ForceRegistry.FORCE_SHEARS.get());
+
+		this.tag(ItemTags.PICKAXES)
+				.add(ForceRegistry.FORCE_PICKAXE.get());
+
+		this.tag(ItemTags.SHOVELS)
+				.add(ForceRegistry.FORCE_SHOVEL.get());
+
+		this.tag(ItemTags.AXES)
+				.add(ForceRegistry.FORCE_AXE.get());
+
+		this.tag(Tags.Items.TOOLS_BOW)
+				.add(ForceRegistry.FORCE_BOW.get());
+
+		this.tag(ItemTags.SWORDS)
+				.add(ForceRegistry.FORCE_SWORD.get());
+
+		this.tag(Tags.Items.TOOLS_SHEAR)
+				.add(ForceRegistry.FORCE_SHEARS.get());
+
 	}
 }


### PR DESCRIPTION
This adds tags to all force tools (axe, shovel, pickaxe, sword, bow, shears).

This resolves #94.